### PR TITLE
优化隐藏键盘的判断逻辑

### DIFF
--- a/xpage-lib/src/main/java/com/xuexiang/xpage/utils/Utils.java
+++ b/xpage-lib/src/main/java/com/xuexiang/xpage/utils/Utils.java
@@ -162,11 +162,12 @@ public final class Utils {
             if (!isTouchView) {
                 continue;
             }
-            // 判断点击的是否是 EditText
+            // 如果点击的是 EditText，就结束循环
             if (childView instanceof EditText) {
                 isConsume = true;
+                break;
             }
-            // 递归遍历当前 View 树
+            // 否则，递归遍历当前 View 树，继续寻找 EditText
             else if (childView instanceof ViewGroup) {
                 ViewGroup itemView = (ViewGroup) childView;
                 isConsume = childInterceptEvent(itemView, touchX, touchY);


### PR DESCRIPTION
**问题描述：**
当一个页面中有多个 EditText 的时候，如果不做更多的判断，从一个 EditText 跳到 另一个 EditText 会出现软键盘跳动的现象。
**解决方法：**
递归遍历当前 View 树，如果点击事件落到了 EditText 上，那么就不隐藏软键盘。
**实现效果：**
多个EditText之间的软键盘可以无缝切换。